### PR TITLE
Automates release creation

### DIFF
--- a/.scripts/package.sh
+++ b/.scripts/package.sh
@@ -334,8 +334,19 @@ if [[ $latest != $current || $debug ]]; then
     # Deploy to repository
     echo "Merging changes to Github..."
     commit_changes "release/$latest"
-    echo "Creating release draft"
-    echo "Release $latest" | gh release create --target "release/$latest" --draft $latest $scratch/dist/*.xcframework.zip
+
+    # Tag this commit to enable automatic release creation
+    if git rev-parse "$latest" >/dev/null 2>&1; then
+        echo "Tag $latest already exists. Skipping."
+    else
+        # Tag the current commit with the version
+        git tag "$latest"
+        # Push the tag to the remote repository
+        git push origin "$latest"
+    fi
+
+    echo "Creating release"
+    echo "Release $latest" | gh release create --target "release/$latest" --title "Release $latest" $latest $scratch/dist/*.xcframework.zip
 else
     echo "$current is up to date."
 fi


### PR DESCRIPTION
### Scope
You've made a super handy project @akaffenberger, but we can only access public releases and that's the bit that seems to take your time.

As such, this PR changes the flow to automatically tag newly created releases and publish them so the flow is fully automated.

Specifically if there's a new version
* Tag the release commit
* Create the release based on that commit without a draft

