### PR TITLE
Updates script to look for and extract the firebase zip in a subfolde…

### DIFF
--- a/.scripts/package.sh
+++ b/.scripts/package.sh
@@ -260,6 +260,45 @@ generate_swift_package () {
     template_replace $package "// GENERATE BINARIES" $binaries; rm -f $binaries
 }
 
+find_and_extract_firebase_zip() {
+    echo "Looking for downloaded Firebase zip..."
+    
+    # Find the zip file and ensure it's called Firebase.zip
+    zip_file=$(find . -name "*.zip" | head -n 1)
+    
+    if [ -n "$zip_file" ]; then
+        echo "Found downloaded zip file: $zip_file"
+        mv "$zip_file" "Firebase.zip"
+        unzip -q Firebase.zip
+    else
+        echo "No downloaded zip file found in root directory. Exiting."
+        exit 1
+    fi
+    
+    # If there's no Firebase folder at the root, look for a relevant zip file and unzip it
+    if [ ! -d "Firebase" ]; then
+        echo "Firebase directory not found in root. Looking for zip file in subdirectories..."
+        # Look for Firebase zip files in subdirectories (excluding carthage)
+        for dir in */; do
+            if [ -d "$dir" ] && [ "$dir" != "carthage/" ]; then
+                firebase_zip=$(find "$dir" -name "Firebase*.zip" | head -n 1)
+                if [ -n "$firebase_zip" ]; then
+                    echo "Found Firebase zip in $dir: $firebase_zip"
+                    unzip -q "$firebase_zip"
+                    break
+                fi
+            fi
+        done
+        # Did we find the right Firebase directory?
+        if [ ! -d "Firebase" ]; then
+            echo "Firebase directory not found in any subdirectory. Exiting."
+            exit 1
+        fi
+    fi
+    
+    echo "Firebase zip found and extracted successfully"
+}
+
 commit_changes() {
     branch=$1
     git checkout -b $branch
@@ -299,8 +338,8 @@ if [[ $latest != $current || $debug ]]; then
         home=$OLDPWD
         echo "Downloading latest release..."
         gh release download --pattern 'Firebase.zip' --repo $firebase_repo
-        echo "Unzipping.."
-        unzip -q Firebase.zip
+        
+        find_and_extract_firebase_zip
         echo "Preparing xcframeworks for distribution..."
         cd Firebase
         rename_frameworks "_"


### PR DESCRIPTION
### TL;DR;
* Fix the change in zip structure. Updates script to look for and extract the firebase zip in a subfolder if working on a changed file / folder structure.

### Context
* Firebase changed the file structure from all the dependencies being at the root to being doubly zipped with other folders at the root
* This script change adds a fallback that looks for the `Firebase` directory at the root, if it doesn't find it, it looks for a `Firebase*...zip` in a subdirectory (that isn't Carthage)
    * If found, it extracts the versioned zip and checks if we now have the expected Firebase directory

*Before*
![Before](https://github.com/user-attachments/assets/5aded76b-4ece-4c1e-a1e9-17be3827e119)

*After*
![After](https://github.com/user-attachments/assets/7f6cb07e-f2de-4f71-b3b1-391306d71c47)

Once we've extracted this nested zip, the folder structure is _currently_ as before.